### PR TITLE
Fixed awkward "try it again" login failure message

### DIFF
--- a/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/includes/i18n/security_en_US.properties
+++ b/modules/contentbox/modules/contentbox-admin/modules/contentbox-security/includes/i18n/security_en_US.properties
@@ -13,7 +13,7 @@ lostpassword = Lost Password
 
 lostpassword.instructions = Enter your email address below in order to be sent a link to reset your password.
 
-messages.invalid_credentials     = Invalid Credentials, try it again!
+messages.invalid_credentials     = Invalid Credentials, please try again!
 messages.invalid_password        = Please enter a valid password
 messages.invalid_token           = The security reset token passed is invalid or has expired.
 messages.ip_blocked              = This IP has been blocked.


### PR DESCRIPTION
This commit fixes the english wording for the "try again" login failure message in English.